### PR TITLE
return_type='file' now returns filenames instead of File objects

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -197,7 +197,7 @@ class Layout(object):
             return_type (str): Type of result to return. Valid values:
                 'tuple': returns a list of namedtuples containing file name as
                     well as attribute/value pairs for all named entities.
-                'file': returns a list of File instances.
+                'file': returns a list of matching filenames.
                 'dir': returns a list of directories.
                 'id': returns a list of unique IDs. Must be used together with
                     a valid target.
@@ -222,7 +222,7 @@ class Layout(object):
             result.append(file)
 
         if return_type == 'file':
-            return result
+            return natural_sort([f.path for f in result])
 
         if return_type == 'tuple':
             result = [r.as_named_tuple() for r in result]

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -127,6 +127,8 @@ class TestLayout:
         result = layout.get(target='subject', return_type='dir')
         assert os.path.exists(result[0])
         assert os.path.isdir(result[0])
+        result = layout.get(target='subject', type='phasediff', return_type='file')
+        assert all([os.path.exists(f) for f in result])
 
     def test_unique_and_count(self, layout):
         result = layout.unique('subject')


### PR DESCRIPTION
Closes #4. Aside from the concern about naming confusion in #4, there's no good reason to return File instances given that the default namedtuples already provide attribute access to all fields in the File. Wanting just the filenames is probably a much more common use case, so `return_type='file'` now returns only filenames.