### PR TITLE
BF+ENH: make tests "useful", adjusted test.json to point to actual values, allow for numericals to have leading 0

### DIFF
--- a/grabbit/tests/specs/test.json
+++ b/grabbit/tests/specs/test.json
@@ -2,19 +2,19 @@
   "entities": [
     {
       "name": "subject",
-      "pattern": "(sub-\\d+)",
+      "pattern": "sub-(\\d+)",
       "directory": "{{root}}/{subject}"
     },
     {
       "name": "session",
-      "pattern": "(ses-\\d)",
+      "pattern": "ses-0*(\\d+)",
       "mandatory": false,
       "directory": "{{root}}/{subject}/{session}",
       "missing_value": "ses-1"
     },
     {
       "name": "run",
-      "pattern": "(run-\\d+)"
+      "pattern": "run-0*(\\d+)"
     },
     {
       "name": "type",


### PR DESCRIPTION
Please correct me if anything is wrong. 
Apparently currently test was simply useless (pardon if sounds rude ;) ) -- it
was not testing if any hits were returned and then was checking only
assumptions within the returned empty list, thus succeeding since nothing
invalidated the assumptions

another really confusing to me was the dichotomy between name and meaning of
"regex_match", which according to the description and to the implementation was
actually "regex_search" ;)  To make breakage explicit, if someone changed the
default value, I decided to fix the name, instead of reverting the logic in the
code.

edit 1: I also changed the sample test.json regexes to strip away prefixes such as 'sub-' etc, and some times even to swallow leading 0s in the numbers, although also introduced logic in the code to prepend leading 0s to the regex if target value was provided as a number.  This then should satisfy tests better (with lesser modifications), but then example notebook would be quite diverging from this.  I will fix notebook to follow this convention of not requiring prefixes

P.S.1 otherwise looks very lovely!  
P.S.2 next I am to fixup the example notebook
P.S.3 sorry for clumping multiple changes together