### PR TITLE
Added ability to exclude directories by regex, plus tests

### DIFF
--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -17,7 +17,7 @@ def layout():
     #  in this test.json 'subject' regex was left to contain possible leading 0
     #  the other fields (run, session) has leading 0 stripped
     config = os.path.join(os.path.dirname(__file__), 'specs', 'test.json')
-    return Layout(root, config, regex_search=True)
+    return Layout(root, config, regex_search=True, exclude_dir='derivatives')
 
 
 class TestFile:
@@ -170,3 +170,7 @@ class TestLayout:
                                      return_type='tuple')
         assert len(nearest) == 3
         assert nearest[0].subject == '01'
+
+    def test_exclude_regex(self, layout):
+        assert os.path.join(
+            layout.root, 'derivatives/excluded.json') not in layout.files


### PR DESCRIPTION
You can specify a directory to recursively exclude from indexing using regex with the "exclude_dir" flag.

Note that it modifies the os.walk tree inplace, which means that directories that match the regex will be excluded from future walking, making the search more efficient. 

All tests pass locally. 