### PR TITLE
add strict matching option in get_nearest

### DIFF
--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -162,11 +162,14 @@ class TestLayout:
     def test_get_nearest(self, layout):
         result = layout.get(subject='01', run=1, session=1, type='phasediff',
                             extensions='.json', return_type='file')[0]
-        nearest = layout.get_nearest(result, type='sessions', extensions='tsv')
+        nearest = layout.get_nearest(result, type='sessions', extensions='tsv',
+                                     ignore_strict_entities=['type'])
         assert '7t_trt/sub-01/sub-01_sessions.tsv' in nearest
-        nearest = layout.get_nearest(result, extensions='tsv', all_=True)
+        nearest = layout.get_nearest(result, extensions='tsv', all_=True,
+                                     ignore_strict_entities=['type'])
         assert len(nearest) == 3
         nearest = layout.get_nearest(result, extensions='tsv', all_=True,
-                                     return_type='tuple')
+                                     return_type='tuple',
+                                     ignore_strict_entities=['type'])
         assert len(nearest) == 3
         assert nearest[0].subject == '01'


### PR DESCRIPTION
Adds the ability to enforce strict matching when calling `get_nearest`. This allows one to ignore files that may share many entities but also differ in at least one shared entity. For example, given the path `/7t_trt/sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz`, we might not want `get_nearest(path, extensions='tsv')` to return the file `sub-01_ses-1_task-rest_acq-fullbrain_run-1_events.tsv`, because even though the target and candidate share many entity values ('sub', 'ses', 'task', acq'), they differ on one entity ('run') that rules the candidate inadmissible. When `strict=True`, such partial matches will be ignored.

Importantly, this also introduces a second argument `ignore_strict_entities` that allows some entities to be excluded from this restriction. This is important when, for example, one wants to retrieve the nearest file of a different type, while still enforcing strict matching for all entities other than type.