### PR TITLE
Added index to config, and ability to exclude/include top level dirs …

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -192,7 +192,6 @@ class Layout(object):
             #if they match exclude regex
             if root == self.root:
                 if self.index_regex:
-                    print(root)
                     if 'exclude' in self.index_regex:
                         for exclude_regex in self.index_regex['exclude']:
                             directories[:] = [d for d in directories \

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -223,7 +223,7 @@ class Layout(object):
                               filter(self._validate_dir, full_dirs)]
             for f in filenames:
                 f = File(join(root, f))
-                if self._check_inclusions(f) or self._validate_file(f):
+                if not (self._check_inclusions(f) and self._validate_file(f)):
                     continue
                 for e in self.entities.values():
                     e.matches(f)

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -223,7 +223,7 @@ class Layout(object):
                               filter(self._validate_dir, full_dirs)]
             for f in filenames:
                 f = File(join(root, f))
-                if not self._check_inclusions(f) and self._validate_file(f):
+                if not (self._check_inclusions(f) and self._validate_file(f)):
                     continue
                 for e in self.entities.values():
                     e.matches(f)

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -153,7 +153,7 @@ class Layout(object):
         self.mandatory = set()
         self.dynamic_getters = dynamic_getters
         self.regex_search = regex_search
-        self.filtering_regex = None
+        self.filtering_regex = {}
 
         if config is not None:
             self._load_config(config)

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -173,20 +173,19 @@ class Layout(object):
         self.index()
 
     def _validate_file(self, f):
-        ''' Override this in subclasses to provide additional file validation.
+        ''' Extend this in subclasses to provide additional file validation.
         Will be called the first time each file is read in; if False is
         returned, the file will be ignored and dropped from the layout. '''
         filename = f if isinstance(f, str) else f.filename
+
         # If file matches any include regex, then true
-        ### For else?
-        ### If no explicit include, assume include all
-        include = False
-        for regex in self.index_regex.get('include', []):
-            if re.match(regex, filename):
-                include = True
-                break
-        if not include:
-            return False
+        include_regex = self.index_regex.get('include', [])
+        if include_regex:
+            for regex in include_regex:
+                if re.match(regex, filename):
+                    break
+            else:
+                return False
 
         # If file matches any excldue regex, then false
         for regex in self.index_regex.get('exclude', []):

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -223,7 +223,7 @@ class Layout(object):
                               filter(self._validate_dir, full_dirs)]
             for f in filenames:
                 f = File(join(root, f))
-                if not (self._check_inclusions(f) and self._validate_file(f)):
+                if self._check_inclusions(f) or self._validate_file(f):
                     continue
                 for e in self.entities.values():
                     e.matches(f)

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -174,7 +174,7 @@ class Layout(object):
             if self.inclusion_regex.get('include') and \
                 self.inclusion_regex.get('exclude'):
                     raise ValueError("You can only define either include or "
-                                     " exclude regex, not both.")
+                                     "exclude regex, not both.")
         self.index()
 
     def _check_inclusions(self, f):

--- a/grabbit/tests/specs/test.json
+++ b/grabbit/tests/specs/test.json
@@ -1,6 +1,6 @@
 {
   "index" : {
-    "exclude" : ["derivatives"]
+    "exclude" : [".*derivatives.*"]
   },
   "entities": [
     {

--- a/grabbit/tests/specs/test.json
+++ b/grabbit/tests/specs/test.json
@@ -1,7 +1,7 @@
 {
   "index" : {
     "exclude" : ["derivatives"],
-    "include" : ["sub-(\\d+)"]
+    "include" : ["sub-(\\d+)", "ses-.*", "func", "fmap", ".*\\..*"]
   },
   "entities": [
     {

--- a/grabbit/tests/specs/test.json
+++ b/grabbit/tests/specs/test.json
@@ -1,4 +1,8 @@
 {
+  "index" : {
+    "exclude" : ["derivatives"],
+    "include" : ["sub-(\\d+)"]
+  },
   "entities": [
     {
       "name": "subject",

--- a/grabbit/tests/specs/test_include.json
+++ b/grabbit/tests/specs/test_include.json
@@ -1,6 +1,6 @@
 {
   "index" : {
-    "exclude" : ["derivatives"]
+    "include" : ["sub-(\\d+)", "ses-.*", "func", "fmap", ".*\\..*"]
   },
   "entities": [
     {

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -17,7 +17,7 @@ def layout():
     #  in this test.json 'subject' regex was left to contain possible leading 0
     #  the other fields (run, session) has leading 0 stripped
     config = os.path.join(os.path.dirname(__file__), 'specs', 'test.json')
-    return Layout(root, config, regex_search=True, exclude_dir='derivatives')
+    return Layout(root, config, regex_search=True)
 
 
 class TestFile:
@@ -174,6 +174,8 @@ class TestLayout:
         assert len(nearest) == 3
         assert nearest[0].subject == '01'
 
-    def test_exclude_regex(self, layout):
+    def test_index_regex(self, layout):
         assert os.path.join(
             layout.root, 'derivatives/excluded.json') not in layout.files
+        assert os.path.join(
+            layout.root, 'models/excluded_model.json') not in layout.files

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -19,6 +19,14 @@ def layout():
     config = os.path.join(os.path.dirname(__file__), 'specs', 'test.json')
     return Layout(root, config, regex_search=True)
 
+@pytest.fixture(scope='module')
+def layout2():
+    root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')
+    # note about test.json:
+    #  in this test.json 'subject' regex was left to contain possible leading 0
+    #  the other fields (run, session) has leading 0 stripped
+    config = os.path.join(os.path.dirname(__file__), 'specs', 'test_include.json')
+    return Layout(root, config, regex_search=True)
 
 class TestFile:
 
@@ -174,8 +182,8 @@ class TestLayout:
         assert len(nearest) == 3
         assert nearest[0].subject == '01'
 
-    def test_index_regex(self, layout):
+    def test_index_regex(self, layout, layout2):
         assert os.path.join(
             layout.root, 'derivatives/excluded.json') not in layout.files
         assert os.path.join(
-            layout.root, 'models/excluded_model.json') not in layout.files
+            layout2.root, 'models/excluded_model.json') not in layout2.files

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -29,7 +29,7 @@ def layout2():
 def layout_override():
     root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')
     config = os.path.join(os.path.dirname(__file__), 'specs', 'test.json')
-    return Layout(root, config, config_update = {'index': None}, regex_search=True)
+    return Layout(root, config, regex_search=True, index={})
 
 class TestFile:
 
@@ -190,6 +190,6 @@ class TestLayout:
             layout.root, 'derivatives/excluded.json') not in layout.files
         assert os.path.join(
             layout_override.root, 'derivatives/excluded.json') \
-            not in layout_override.files
+            in layout_override.files
         assert os.path.join(
             layout2.root, 'models/excluded_model.json') not in layout2.files

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -1,7 +1,7 @@
 import pytest
 from grabbit import File, Entity, Layout
 import os
-
+import json
 
 @pytest.fixture
 def file(tmpdir):
@@ -24,12 +24,6 @@ def layout2():
     root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')
     config = os.path.join(os.path.dirname(__file__), 'specs', 'test_include.json')
     return Layout(root, config, regex_search=True)
-
-@pytest.fixture(scope='module')
-def layout_override():
-    root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')
-    config = os.path.join(os.path.dirname(__file__), 'specs', 'test.json')
-    return Layout(root, config, regex_search=True, index={})
 
 class TestFile:
 
@@ -185,11 +179,13 @@ class TestLayout:
         assert len(nearest) == 3
         assert nearest[0].subject == '01'
 
-    def test_index_regex(self, layout, layout2, layout_override):
+    def test_index_regex(self, layout, layout2):
         assert os.path.join(
             layout.root, 'derivatives/excluded.json') not in layout.files
         assert os.path.join(
-            layout_override.root, 'derivatives/excluded.json') \
-            in layout_override.files
-        assert os.path.join(
             layout2.root, 'models/excluded_model.json') not in layout2.files
+
+        with pytest.raises(ValueError):
+            layout2._load_config({'entities' : [],
+                                  'index' : {'include' : 'test',
+                                             'exclude' : 'test'}})

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -22,11 +22,14 @@ def layout():
 @pytest.fixture(scope='module')
 def layout2():
     root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')
-    # note about test.json:
-    #  in this test.json 'subject' regex was left to contain possible leading 0
-    #  the other fields (run, session) has leading 0 stripped
     config = os.path.join(os.path.dirname(__file__), 'specs', 'test_include.json')
     return Layout(root, config, regex_search=True)
+
+@pytest.fixture(scope='module')
+def layout_override():
+    root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')
+    config = os.path.join(os.path.dirname(__file__), 'specs', 'test.json')
+    return Layout(root, config, config_update = {'index': None}, regex_search=True)
 
 class TestFile:
 
@@ -182,8 +185,11 @@ class TestLayout:
         assert len(nearest) == 3
         assert nearest[0].subject == '01'
 
-    def test_index_regex(self, layout, layout2):
+    def test_index_regex(self, layout, layout2, layout_override):
         assert os.path.join(
             layout.root, 'derivatives/excluded.json') not in layout.files
+        assert os.path.join(
+            layout_override.root, 'derivatives/excluded.json') \
+            not in layout_override.files
         assert os.path.join(
             layout2.root, 'models/excluded_model.json') not in layout2.files


### PR DESCRIPTION
- To address #17 , include and exclude regex for top levels dir can be specified in "index" key of config.json.
- Added tests to cover folders that should be included/excluded, and all are passing