### PR TITLE
Read/write index files

### DIFF
--- a/grabbit/__init__.py
+++ b/grabbit/__init__.py
@@ -1,1 +1,7 @@
-from .core import *
+from .core import File, Entity, Layout
+
+__all__ = [
+    'File',
+    'Entity',
+    'Layout'
+]

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -6,7 +6,6 @@ from grabbit.external import six, inflect
 from grabbit.utils import natural_sort
 from os.path import join, basename, dirname, abspath, split
 from functools import partial
-import six
 
 
 __all__ = ['File', 'Entity', 'Layout']
@@ -61,7 +60,8 @@ class File(object):
         Returns the File as a named tuple. The full path plus all entity
         key/value pairs are returned as attributes.
         """
-        _File = namedtuple('File', 'filename ' + ' '.join(self.entities.keys()))
+        _File = namedtuple('File', 'filename ' +
+                           ' '.join(self.entities.keys()))
         return _File(filename=self.path, **self.entities)
 
 
@@ -168,17 +168,17 @@ class Layout(object):
         if 'index' in config:
             self.filtering_regex = config['index']
             if self.filtering_regex.get('include') and \
-                self.filtering_regex.get('exclude'):
-                    raise ValueError("You can only define either include or "
-                                     "exclude regex, not both.")
+               self.filtering_regex.get('exclude'):
+                raise ValueError("You can only define either include or "
+                                 "exclude regex, not both.")
         self.index()
 
     def _check_inclusions(self, f):
-        ''' Check if file or directory against regexes in config to determine if
+        ''' Check file or directory against regexes in config to determine if
             it should be included in the index '''
         filename = f if isinstance(f, six.string_types) else f.path
 
-        # If file matches any include regex, then true
+        # If file matches any include regex, then True
         include_regex = self.filtering_regex.get('include', [])
         if include_regex:
             for regex in include_regex:
@@ -197,7 +197,8 @@ class Layout(object):
     def _validate_dir(self, d):
         ''' Extend this in subclasses to provide additional directory validation.
         Will be called the first time a directory is read in; if False is
-        returned, the directory will be ignored and dropped from the layout. '''
+        returned, the directory will be ignored and dropped from the layout.
+        '''
 
         return self._validate_file(d)
 
@@ -230,8 +231,8 @@ class Layout(object):
             # Exclude directories that match exclude regex from further search
             full_dirs = [os.path.join(root, d) for d in directories]
             full_dirs = filter(self._check_inclusions, full_dirs)
-            directories[:] = [os.path.split(d)[1] for d in \
-                        filter(self._validate_dir, full_dirs)]
+            directories[:] = [os.path.split(d)[1] for d in
+                              filter(self._validate_dir, full_dirs)]
 
             for f in filenames:
 
@@ -255,17 +256,17 @@ class Layout(object):
 
     def add_entity(self, **kwargs):
             # Set up the entities we need to track
-            ent = Entity(**kwargs)
-            if ent.mandatory:
-                self.mandatory.add(ent.name)
-            if ent.directory is not None:
-                ent.directory = ent.directory.replace('{{root}}', self.root)
-            self.entities[ent.name] = ent
-            if self.dynamic_getters:
-                func = partial(getattr(self, 'get'), target=ent.name,
-                               return_type='id')
-                func_name = inflect.engine().plural(ent.name)
-                setattr(self, 'get_%s' % func_name, func)
+        ent = Entity(**kwargs)
+        if ent.mandatory:
+            self.mandatory.add(ent.name)
+        if ent.directory is not None:
+            ent.directory = ent.directory.replace('{{root}}', self.root)
+        self.entities[ent.name] = ent
+        if self.dynamic_getters:
+            func = partial(getattr(self, 'get'), target=ent.name,
+                           return_type='id')
+            func_name = inflect.engine().plural(ent.name)
+            setattr(self, 'get_%s' % func_name, func)
 
     def get(self, return_type='tuple', target=None, extensions=None,
             regex_search=None, **kwargs):
@@ -335,7 +336,7 @@ class Layout(object):
                     patt = self.entities[ent].pattern
                     template = template.replace('{%s}' % ent, patt)
                 template += '[^\%s]*$' % os.path.sep
-                matches = [f.dirname for f in self.files.values() \
+                matches = [f.dirname for f in self.files.values()
                            if re.search(template, f.dirname)]
                 return natural_sort(list(set(matches)))
 
@@ -428,6 +429,7 @@ class Layout(object):
         for filename in results:
             f = self.files[filename]
             folders[f.dirname].append(f)
+
         def count_matches(f):
             keys = set(entities.keys()) & set(f.entities.keys())
             shared = len(keys)
@@ -457,7 +459,7 @@ class Layout(object):
                 if _path == path:
                     break
                 path = _path
-            except:
+            except Exception:
                 break
 
         matches = [m.path if return_type == 'file' else m.as_named_tuple()

--- a/grabbit/tests/misc/index.json
+++ b/grabbit/tests/misc/index.json
@@ -1,0 +1,130 @@
+{
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/dataset_description.json": {
+    "type": "description"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/participants.tsv": {
+    "type": "trt/participants"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/task-rest_acq-fullbrain_bold.json": {
+    "type": "bold",
+    "task": "rest_acq"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/task-rest_acq-fullbrain_run-1_physio.json": {
+    "run": "1",
+    "type": "physio",
+    "task": "rest_acq",
+    "acquisition": "fullbrain_run"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/task-rest_acq-fullbrain_run-2_physio.json": {
+    "run": "2",
+    "type": "physio",
+    "task": "rest_acq",
+    "acquisition": "fullbrain_run"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/task-rest_acq-prefrontal_bold.json": {
+    "type": "bold",
+    "task": "rest_acq"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/task-rest_acq-prefrontal_physio.json": {
+    "type": "physio",
+    "task": "rest_acq"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/test.bval": {
+    "type": "trt/test",
+    "bval": "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/test.bval"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/models/excluded_model.json": {
+    "type": "model"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/sub-01_sessions.tsv": {
+    "subject": "01",
+    "type": "sessions"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/sub-01_ses-1_scans.tsv": {
+    "subject": "01",
+    "session": "1",
+    "type": "scans"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/anat/sub-01_ses-1_T1map.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "type": "T1map"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/anat/sub-01_ses-1_T1w.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "type": "T1w"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-1_magnitude1.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "1",
+    "type": "magnitude1"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-1_magnitude2.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "1",
+    "type": "magnitude2"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-1_phasediff.json": {
+    "subject": "01",
+    "session": "1",
+    "run": "1",
+    "type": "phasediff"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-1_phasediff.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "1",
+    "type": "phasediff"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-2_magnitude1.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "2",
+    "type": "magnitude1"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-2_magnitude2.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "2",
+    "type": "magnitude2"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-2_phasediff.json": {
+    "subject": "01",
+    "session": "1",
+    "run": "2",
+    "type": "phasediff"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-2_phasediff.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "2",
+    "type": "phasediff"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "1",
+    "type": "bold",
+    "task": "rest_acq",
+    "acquisition": "fullbrain_run"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-1_physio.tsv.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "1",
+    "type": "physio",
+    "task": "rest_acq",
+    "acquisition": "fullbrain_run"
+  },
+  "/mnt/c/Users/tyark/Dropbox/Code/grabbit/grabbit/tests/data/7t_trt/sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz": {
+    "subject": "01",
+    "session": "1",
+    "run": "2",
+    "type": "bold",
+    "task": "rest_acq",
+    "acquisition": "fullbrain_run"
+  }
+}

--- a/grabbit/tests/specs/test_with_mapper.json
+++ b/grabbit/tests/specs/test_with_mapper.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "hash",
-      "mapper": "hash_file"
+      "map_func": "hash_file"
     }
   ]
 }

--- a/grabbit/tests/specs/test_with_mapper.json
+++ b/grabbit/tests/specs/test_with_mapper.json
@@ -1,0 +1,43 @@
+{
+  "index" : {
+    "exclude" : [".*derivatives.*"]
+  },
+  "entities": [
+    {
+      "name": "subject",
+      "pattern": "sub-(\\d+)",
+      "directory": "{{root}}/{subject}"
+    },
+    {
+      "name": "session",
+      "pattern": "ses-0*(\\d+)",
+      "mandatory": false,
+      "directory": "{{root}}/{subject}/{session}",
+      "missing_value": "ses-1"
+    },
+    {
+      "name": "run",
+      "pattern": "run-0*(\\d+)"
+    },
+    {
+      "name": "type",
+      "pattern": ".*_(.*?)\\."
+    },
+    {
+      "name": "task",
+      "pattern": "task-(.*?)-"
+    },
+    {
+      "name": "acquisition",
+      "pattern": "acq-(.*?)-"
+    },
+    {
+      "name": "bval",
+      "pattern": "(.*\\.bval)"
+    },
+    {
+      "name": "hash",
+      "mapper": "hash_file"
+    }
+  ]
+}

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -262,14 +262,20 @@ class TestLayout:
         assert layout.unique('subject') == ['01']
         assert len(layout.files) == 24
 
+        # Test with reindexing
+        f = os.path.join(os.path.dirname(__file__), 'misc', 'index.json')
+        layout.load_index(f, reindex=True)
+        assert layout.unique('subject') == ['01']
+        assert len(layout.files) == 24
+
     def test_entity_mapper(self, layout):
 
         class EntityMapper(object):
-            def hash_file(self, file, layout):
+            def hash_file(self, file):
                 return hash(file.path)
 
         class MappingLayout(Layout):
-            def hash_file(self, file, layout):
+            def hash_file(self, file):
                 return str(hash(file.path)) + '.hsh'
 
         root = os.path.join(os.path.dirname(__file__), 'data', '7t_trt')


### PR DESCRIPTION
Adds the ability to save the current file/entity index to a file, and also to reconstruct the `Layout` from an index. Note that in the latter case,  a .json config file is still required--i.e., the `Entity` definitions and other `Layout` settings are not stored in the index file.

The format of the index is just a simple .json file with full file paths as keys, and entity key/value pairs as values. I.e., this:

```json
{
  "filename1": {
    "entity1": "value1",
    "entity2": "value2",
    ...
  }
}
```

@mih and @yarikoptic, does that work for you? I expect you probably won't need to touch this at all, since you can just construct the `Layout` object on-the-fly from the index file and config file, and then use that for queriesa, without needing to directly query on the index file itself. But if you anticipate needing to build a master index for whoosh directly from the index files, let me know if you'd prefer a different format.