### PR TITLE
allow lists when matching files by entity

### DIFF
--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -59,6 +59,11 @@ class TestFile:
         assert not file._matches(entities={'task': 'rest', 'run': 4})
         assert not file._matches(entities={'task': 'st'})
         assert file._matches(entities={'task': 'st'}, regex_search=True)
+        # With list of matches
+        assert not file._matches(entities={'task': ['A', 'B', 'C']})
+        assert file._matches(entities={'task': ['A', 'B', 'rest']})
+        assert file._matches(entities={'task': ['A', 'B', 'st']},
+                             regex_search=True)
 
     def test_named_tuple(self, file):
         file.entities = {'attrA': 'apple', 'attrB': 'banana'}


### PR DESCRIPTION
This addresses INCF/pybids#42 by allowing lists to be passed when trying to match entities. Lists are now valid values in any dynamic entity argument (e.g., `layout.get(subject=[1, 2, 3])` will now return all files that match subjects 1, 2, or 3).

Also very slightly optimizes performance by terminating the matching sooner if the entity is completely absent.