### PR TITLE
reworked writable layouts

### DIFF
--- a/grabbit/__init__.py
+++ b/grabbit/__init__.py
@@ -1,6 +1,5 @@
 from .core import File, Entity, Layout, merge_layouts
-from .extensions import (replace_entities, build_path, write_contents_to_file,
-                         WritableFile, WritableLayout)
+from .extensions import (replace_entities, build_path, write_contents_to_file)
 
 __all__ = [
     'File',
@@ -9,7 +8,5 @@ __all__ = [
     'replace_entities',
     'build_path',
     'write_contents_to_file',
-    'WritableFile',
-    'WritableLayout',
     'merge_layouts'
 ]

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -650,7 +650,7 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
     def clone(self):
         return deepcopy(self)
 
-    def build_path(self, source, path_patterns=None):
+    def build_path(self, source, path_patterns=None, strict=False):
         ''' Constructs a target filename for a file or dictionary of entities.
 
         Args:
@@ -664,6 +664,9 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
             path_patterns (list): Optional path patterns to use to construct
                 the new file path. If None, the Layout-defined patterns will
                 be used.
+            strict (bool): If True, all entities must be matched inside a
+                pattern in order to be a valid match. If False, extra entities
+                will be ignored so long as all mandatory entities are found.
         '''
         if isinstance(source, six.string_types):
             source = self.files[source]
@@ -674,7 +677,7 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
         if path_patterns is None:
             path_patterns = self.path_patterns
 
-        return build_path(source, path_patterns)
+        return build_path(source, path_patterns, strict)
 
     def copy_files(self, files=None, path_patterns=None, symbolic_links=True,
                    root=None, conflicts='fail', **get_selectors):
@@ -711,7 +714,8 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
     def write_contents_to_file(self, entities, path_patterns=None,
                                contents=None, link_to=None,
-                               content_mode='text', conflicts='fail'):
+                               content_mode='text', conflicts='fail',
+                               strict=False):
         """
         Write arbitrary data to a file defined by the passed entities and
         path patterns.
@@ -730,11 +734,14 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
             exists. 'fail' raises an exception; 'skip' does nothing;
             'overwrite' overwrites the existing file; 'append' adds a suffix
             to each file copy, starting with 1. Default is 'fail'.
+            strict (bool): If True, all entities must be matched inside a
+                pattern in order to be a valid match. If False, extra entities
+                will be ignored so long as all mandatory entities are found.
 
         """
         if not path_patterns:
             path_patterns = self.path_patterns
-        path = build_path(entities, path_patterns)
+        path = build_path(entities, path_patterns, strict)
         write_contents_to_file(path, contents=contents, link_to=link_to,
                                content_mode=content_mode, conflicts=conflicts,
                                root=self.root)

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -650,10 +650,31 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
     def clone(self):
         return deepcopy(self)
 
-    def build_path(self, entities, path_patterns=None):
+    def build_path(self, source, path_patterns=None):
+        ''' Constructs a target filename for a file or dictionary of entities.
+
+        Args:
+            source (str, File, dict): The source data to use to construct the
+                new file path. Must be one of:
+                - A File object
+                - A string giving the path of a File contained within the
+                  current Layout.
+                - A dict of entities, with entity names in keys and values in
+                  values
+            path_patterns (list): Optional path patterns to use to construct
+                the new file path. If None, the Layout-defined patterns will
+                be used.
+        '''
+        if isinstance(source, six.string_types):
+            source = self.files[source]
+
+        if isinstance(source, File):
+            source = source.entities
+
         if path_patterns is None:
             path_patterns = self.path_patterns
-        return build_path(entities, path_patterns)
+
+        return build_path(source, path_patterns)
 
     def copy_files(self, files=None, path_patterns=None, symbolic_links=True,
                    root=None, conflicts='fail', **get_selectors):

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -4,6 +4,7 @@ import re
 from collections import defaultdict, OrderedDict, namedtuple
 from grabbit.external import six, inflect
 from grabbit.utils import natural_sort, listify
+from grabbit.extensions.writable import build_path, write_contents_to_file
 from os.path import join, basename, dirname, abspath, split
 from functools import partial
 from copy import deepcopy
@@ -75,6 +76,30 @@ class File(object):
         _File = namedtuple('File', 'filename ' +
                            ' '.join(self.entities.keys()))
         return _File(filename=self.path, **self.entities)
+
+    def copy(self, path_patterns, symbolic_link=False, root=None,
+             conflicts='fail'):
+        ''' Copy the contents of a file to a new location, with target
+        filename defined by the current File's entities and the specified
+        path_patterns. '''
+        new_filename = build_path(self.entities, path_patterns)
+        if not new_filename:
+            return None
+
+        if new_filename[-1] == os.sep:
+            new_filename += self.filename
+
+        if symbolic_link:
+            contents = None
+            link_to = self.path
+        else:
+            with open(self.path, 'r') as f:
+                contents = f.read()
+            link_to = None
+
+        write_contents_to_file(new_filename, contents=contents,
+                               link_to=link_to, content_mode='text', root=root,
+                               conflicts=conflicts)
 
 
 class Entity(object):
@@ -177,9 +202,11 @@ class LayoutMetaclass(type):
 class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
     def __init__(self, path, config=None, index=None, dynamic_getters=False,
-                 absolute_paths=True, regex_search=False, entity_mapper=None):
+                 absolute_paths=True, regex_search=False, entity_mapper=None,
+                 path_patterns=None):
         """
         A container for all the files and metadata found at the specified path.
+
         Args:
             path (str): The root path of the layout.
             config (str, list): The path to the JSON config file that defines
@@ -215,6 +242,9 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
                     Alternatively, the special string "self" can be passed, in
                 which case the current Layout instance will be used as the
                 entity mapper (implying that the user has subclassed Layout).
+            path_patterns (str, list): One or more filename patterns to use
+                as a default path pattern for this layout's files.  Can also
+                be specified in the config file.
         """
 
         self.root = abspath(path) if absolute_paths else path
@@ -225,6 +255,7 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
         self.regex_search = regex_search
         self.filtering_regex = {}
         self.entity_mapper = self if entity_mapper == 'self' else entity_mapper
+        self.path_patterns = path_patterns if path_patterns else []
 
         if config is not None:
             self._load_config(config)
@@ -254,6 +285,9 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
                self.filtering_regex.get('exclude'):
                 raise ValueError("You can only define either include or "
                                  "exclude regex, not both.")
+
+        if 'default_path_patterns' in config:
+            self.path_patterns += listify(config['default_path_patterns'])
 
         return config
 
@@ -615,6 +649,75 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
     def clone(self):
         return deepcopy(self)
+
+    def build_path(self, entities, path_patterns=None):
+        if path_patterns is None:
+            path_patterns = self.path_patterns
+        return build_path(entities, path_patterns)
+
+    def copy_files(self, files=None, path_patterns=None, symbolic_links=True,
+                   root=None, conflicts='fail', **get_selectors):
+        """
+        Copies one or more Files to new locations defined by each File's
+        entities and the specified path_patterns.
+
+        Args:
+            files (list): Optional list of File objects to write out. If none
+                provided, use files from running a get() query using remaining
+                **kwargs.
+            path_patterns (str, list): Write patterns to pass to each file's
+                write_file method.
+            symbolic_links (bool): Whether to copy each file as a symbolic link
+                or a deep copy.
+            root (str): Optional root directory that all patterns are relative
+                to. Defaults to current working directory.
+            conflicts (str): One of 'fail', 'skip', 'overwrite', or 'append'
+                that defines the desired action when a output path already
+                exists. 'fail' raises an exception; 'skip' does nothing;
+                'overwrite' overwrites the existing file; 'append' adds a
+                suffix
+                to each file copy, starting with 0. Default is 'fail'.
+            **get_selectors (kwargs): Optional key word arguments to pass into
+                a get() query.
+        """
+        _files = self.get(return_type='objects', **get_selectors)
+        if files:
+            _files = list(set(files).intersection(_files))
+
+        for f in _files:
+            f.copy(path_patterns, symbolic_link=symbolic_links,
+                   root=root, conflicts=conflicts)
+
+    def write_contents_to_file(self, entities, path_patterns=None,
+                               contents=None, link_to=None,
+                               content_mode='text', conflicts='fail'):
+        """
+        Write arbitrary data to a file defined by the passed entities and
+        path patterns.
+
+        Args:
+            entities (dict): A dictionary of entities, with Entity names in
+                keys and values for the desired file in values.
+            path_patterns (list): Optional path patterns to use when building
+                the filename. If None, the Layout-defined patterns will be
+                used.
+            contents (object): Contents to write to the generate file path.
+                Can be any object serializable as text or binary data (as
+                defined in the content_mode argument).
+            conflicts (str): One of 'fail', 'skip', 'overwrite', or 'append'
+            that defines the desired action when the output path already
+            exists. 'fail' raises an exception; 'skip' does nothing;
+            'overwrite' overwrites the existing file; 'append' adds a suffix
+            to each file copy, starting with 1. Default is 'fail'.
+
+        """
+        if not path_patterns:
+            path_patterns = self.path_patterns
+        path = build_path(entities, path_patterns)
+        write_contents_to_file(path, contents=contents, link_to=link_to,
+                               content_mode=content_mode, conflicts=conflicts,
+                               root=self.root)
+        self._index_file(self.root, path)
 
 
 def merge_layouts(layouts):

--- a/grabbit/extensions/__init__.py
+++ b/grabbit/extensions/__init__.py
@@ -1,12 +1,10 @@
 # from .hdfs import HDFSLayout
-from .writable import (replace_entities, build_path, write_contents_to_file,
-                       WritableFile, WritableLayout)
+from .writable import replace_entities, build_path, write_contents_to_file
+
 
 __all__ = [
     # 'HDFSLayout',
     'replace_entities',
     'build_path',
     'write_contents_to_file',
-    'WritableFile',
-    'WritableLayout'
 ]

--- a/grabbit/extensions/writable.py
+++ b/grabbit/extensions/writable.py
@@ -40,7 +40,7 @@ def replace_entities(entities, pattern):
         return None
 
 
-def build_path(entities, path_patterns):
+def build_path(entities, path_patterns, strict=False):
     """
     Constructs a path given a set of entities and a list of potential
     filename patterns to use.
@@ -53,6 +53,9 @@ def build_path(entities, path_patterns):
             should be denoted by square brackets.
             Pattern example: 'sub-{subject}/[var-{name}/]{id}.csv'
             Example result: 'sub-01/var-SES/1045.csv'
+        strict (bool): If True, all entities must be matched inside a pattern
+            in order to be a valid match. If False, extra entities will be
+            ignored so long as all mandatory entities are found.
 
     Returns:
         A constructed path for this file based on the provided patterns.
@@ -61,6 +64,11 @@ def build_path(entities, path_patterns):
         path_patterns = [path_patterns]
 
     for pattern in path_patterns:
+        # If strict, all entities must be contained in the pattern
+        if strict:
+            defined = re.findall('\{(.*?)\}', pattern)
+            if set(entities.keys()) - set(defined):
+                continue
         # Iterate through the provided path patterns
         new_path = pattern
         optional_patterns = re.findall('\[(.*?)\]', pattern)

--- a/grabbit/extensions/writable.py
+++ b/grabbit/extensions/writable.py
@@ -2,25 +2,23 @@ import logging
 import os
 import re
 import sys
-from grabbit.core import File, Layout
-from grabbit.utils import splitext, listify
+from grabbit.utils import splitext
 from os.path import join, dirname, exists, islink, isabs, isdir
 from six import string_types
 
-__all__ = ['replace_entities', 'build_path', 'write_contents_to_file',
-           'WritableFile', 'WritableLayout']
+__all__ = ['replace_entities', 'build_path', 'write_contents_to_file']
 
 
-def replace_entities(pattern, entities):
+def replace_entities(entities, pattern):
     """
-    Replaces all entity names in the a given pattern with the corresponding
+    Replaces all entity names in a given pattern with the corresponding
     values provided by entities.
 
     Args:
-        pattern (str): A path pattern that contains entity names denoted
-            by curly braces.
-            For example: 'sub-{subject}/{{var-{name}}}/{id}.csv'
         entities (dict): A dictionary mapping entity names to entity values.
+        pattern (str): A path pattern that contains entity names denoted
+            by square brackets.
+            For example: 'sub-{subject}/[var-{name}/]{id}.csv'
 
     Returns:
         A new string with the entity values inserted where entity names
@@ -42,19 +40,19 @@ def replace_entities(pattern, entities):
         return None
 
 
-def build_path(path_patterns, entities):
+def build_path(entities, path_patterns):
     """
     Constructs a path given a set of entities and a list of potential
     filename patterns to use.
 
     Args:
+        entities (dict): A dictionary mapping entity names to entity values.
         path_patterns (str, list): One or more filename patterns to write
             the file to. Entities should be represented by the name
             surrounded by curly braces. Optional portions of the patterns
-            should be denoted by double curly braces.
-            Pattern example: 'sub-{subject}/{{var-{name}}}/{id}.csv'
+            should be denoted by square brackets.
+            Pattern example: 'sub-{subject}/[var-{name}/]{id}.csv'
             Example result: 'sub-01/var-SES/1045.csv'
-        entities (dict): A dictionary mapping entity names to entity values.
 
     Returns:
         A constructed path for this file based on the provided patterns.
@@ -68,7 +66,7 @@ def build_path(path_patterns, entities):
         optional_patterns = re.findall('\[(.*?)\]', pattern)
         # First build from optional patterns if possible
         for optional_pattern in optional_patterns:
-            optional_chunk = replace_entities(optional_pattern, entities)
+            optional_chunk = replace_entities(entities, optional_pattern)
             if optional_chunk:
                 new_path = new_path.replace('[%s]' % optional_pattern,
                                             optional_chunk)
@@ -76,7 +74,7 @@ def build_path(path_patterns, entities):
                 new_path = new_path.replace('[%s]' % optional_pattern,
                                             '')
 
-        new_path = replace_entities(new_path, entities)
+        new_path = replace_entities(entities, new_path)
         # Build from required patterns, only return a valid (not None) path
         if new_path:
             return new_path
@@ -102,7 +100,7 @@ def write_contents_to_file(path, contents=None, link_to=None,
         conflicts (str): One of 'fail', 'skip', 'overwrite', or 'append'
             that defines the desired action when the output path already
             exists. 'fail' raises an exception; 'skip' does nothing;
-            'overwrite' overwrites the existing file; 'append' adds a suffix
+            'overwrite' overwrites the existing file; 'append' adds  a suffix
             to each file copy, starting with 1. Default is 'fail'.
     """
     if not root and not isabs(path):
@@ -150,116 +148,3 @@ def write_contents_to_file(path, contents=None, link_to=None,
             f.write(contents)
     else:
         raise ValueError('One of contents or link_to must be provided.')
-
-
-class WritableFile(File):
-
-    def __init__(self, filename, path_patterns=None):
-        """
-        Represents a file that is writable.
-        """
-        self.path_patterns = path_patterns
-        super(WritableFile, self).__init__(filename)
-
-    def build_path(self, path_patterns=None):
-        if not path_patterns:
-            if self.path_patterns:
-                path_patterns = self.path_patterns
-            else:
-                msg = 'No path patterns specified to build a new path from.'
-                raise ValueError(msg)
-
-        return build_path(path_patterns, self.entities)
-
-    def build_file(self, path_patterns=None, symbolic_link=False,
-                   root=None, conflicts='fail'):
-        new_filename = self.build_path(path_patterns=path_patterns)
-        if not new_filename:
-            return
-
-        if new_filename[-1] == os.sep:
-            new_filename += self.filename
-
-        if symbolic_link:
-            contents = None
-            link_to = self.path
-        else:
-            with open(self.path, 'r') as f:
-                contents = f.read()
-            link_to = None
-
-        write_contents_to_file(new_filename, contents=contents,
-                               link_to=link_to, content_mode='text',
-                               root=root, conflicts=conflicts)
-
-
-class WritableLayout(Layout):
-
-    def __init__(self, path, path_patterns=None, **kwargs):
-        """
-        path_patterns (str, list): One or more filename patterns to use
-                as a default path pattern for this layout's files. See the
-                build_path() method of the File class for more information.
-                Can also be specified in the config file.
-        """
-        self.path_patterns = path_patterns if path_patterns else []
-        super(WritableLayout, self).__init__(path, **kwargs)
-
-    def _load_config(self, config):
-        config = super(WritableLayout, self)._load_config(config)
-        if 'default_path_patterns' in config:
-            self.path_patterns += listify(config['default_path_patterns'])
-        return config
-
-    def _make_file_object(self, root, f):
-        ''' Initialize a new File oject from a directory and filename. Extend
-        in subclasses as needed. '''
-        return WritableFile(join(root, f), path_patterns=self.path_patterns)
-
-    def write_files(self, files=None, path_patterns=None, symbolic_links=True,
-                    root=None, conflicts='fail', **get_selectors):
-        """
-        Writes desired files to new paths as specified by path_patterns.
-
-        Args:
-            files (list): Optional list of File objects to write out. If none
-                provided, use files from running a get() query using remaining
-                **kwargs.
-            path_patterns (str, list): Write patterns to pass to each file's
-                write_file method.
-            symbolic_links (bool): Whether to copy each file as a symbolic link
-                or a deep copy.
-            root (str): Optional root directory that all patterns are relative
-                to. Defaults to current working directory.
-            conflicts (str): One of 'fail', 'skip', 'overwrite', or 'append'
-                that defines the desired action when a output path already
-                exists. 'fail' raises an exception; 'skip' does nothing;
-                'overwrite' overwrites the existing file; 'append' adds a suffix
-                to each file copy, starting with 0. Default is 'fail'.
-            **get_selectors (kwargs): Optional key word arguments to pass into a
-                get() query.
-        """
-        if files:
-            query_files = self.get(return_type='objects', **get_selectors)
-            files = list(set(files).intersection(query_files))
-        else:
-            files = self.get(return_type='objects', **get_selectors)
-
-        for f in files:
-            f.build_file(path_patterns=path_patterns,
-                         symbolic_link=symbolic_links,
-                         root=root,
-                         conflicts=conflicts)
-
-    def write_contents_to_file(self, entities, path_patterns=None,
-                               contents=None, link_to=None,
-                               content_mode='text', conflicts='fail'):
-        """
-        """
-        if not path_patterns:
-            path_patterns = self.path_patterns
-        path = build_path(path_patterns, entities)
-        write_contents_to_file(path, contents=contents, link_to=link_to,
-                               content_mode=content_mode, conflicts=conflicts,
-                               root=self.root)
-        self._index_file(self.root, path)

--- a/grabbit/tests/test_writable.py
+++ b/grabbit/tests/test_writable.py
@@ -1,5 +1,6 @@
 import pytest
-from grabbit import WritableFile, WritableLayout
+from grabbit import Layout, File
+from grabbit.extensions.writable import build_path
 import os
 import shutil
 from os.path import join, exists, islink, dirname
@@ -10,7 +11,7 @@ def writable_file(tmpdir):
     testfile = 'sub-03_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz'
     fn = tmpdir.mkdir("tmp").join(testfile)
     fn.write('###')
-    return WritableFile(os.path.join(str(fn)))
+    return File(os.path.join(str(fn)))
 
 
 class TestWritableFile:
@@ -19,13 +20,11 @@ class TestWritableFile:
         writable_file.entities = {'task': 'rest', 'run': '2', 'subject': '3'}
 
         # Single simple pattern
-        with pytest.raises(ValueError):
-            writable_file.build_path()
+        with pytest.raises(TypeError):
+            build_path(writable_file.entities)
         pat = join(writable_file.dirname, '{task}/sub-{subject}/run-{run}.nii.gz')
         target = join(writable_file.dirname, 'rest/sub-3/run-2.nii.gz')
-        assert writable_file.build_path(pat) == target
-        writable_file.path_patterns = pat
-        assert writable_file.build_path() == target
+        assert build_path(writable_file.entities, pat) == target
 
         # Multiple simple patterns
         pats = ['{session}/{task}/r-{run}.nii.gz',
@@ -33,14 +32,14 @@ class TestWritableFile:
                 '{subject}/{task}.nii.gz']
         pats = [join(writable_file.dirname, p) for p in pats]
         target = join(writable_file.dirname, 't-rest/3-2.nii.gz')
-        assert writable_file.build_path(pats) == target
+        assert build_path(writable_file.entities, pats) == target
 
         # Pattern with optional entity
         pats = ['[{session}/]{task}/r-{run}.nii.gz',
                 't-{task}/{subject}-{run}.nii.gz']
         pats = [join(writable_file.dirname, p) for p in pats]
         target = join(writable_file.dirname, 'rest/r-2.nii.gz')
-        assert writable_file.build_path(pats) == target
+        assert build_path(writable_file.entities, pats) == target
 
     def test_build_file(self, writable_file, tmpdir, caplog):
         writable_file.entities = {'task': 'rest', 'run': '2', 'subject': '3'}
@@ -49,27 +48,27 @@ class TestWritableFile:
         new_dir = join(writable_file.dirname, 'rest')
         pat = join(writable_file.dirname, '{task}/sub-{subject}/run-{run}.nii.gz')
         target = join(writable_file.dirname, 'rest/sub-3/run-2.nii.gz')
-        writable_file.build_file(pat)
+        writable_file.copy(pat)
         assert exists(target)
 
         # Conflict handling
         with pytest.raises(ValueError):
-            writable_file.build_file(pat)
+            writable_file.copy(pat)
         with pytest.raises(ValueError):
-            writable_file.build_file(pat, conflicts='fail')
-        writable_file.build_file(pat, conflicts='skip')
+            writable_file.copy(pat, conflicts='fail')
+        writable_file.copy(pat, conflicts='skip')
         log_message = caplog.records[0].message
         assert log_message == 'A file at path {} already exists, ' \
                               'skipping writing file.'.format(target)
-        writable_file.build_file(pat, conflicts='append')
+        writable_file.copy(pat, conflicts='append')
         append_target = join(writable_file.dirname, 'rest/sub-3/run-2_1.nii.gz')
         assert exists(append_target)
-        writable_file.build_file(pat, conflicts='overwrite')
+        writable_file.copy(pat, conflicts='overwrite')
         assert exists(target)
         shutil.rmtree(new_dir)
 
         # Symbolic linking
-        writable_file.build_file(pat, symbolic_link=True)
+        writable_file.copy(pat, symbolic_link=True)
         assert islink(target)
         shutil.rmtree(new_dir)
 
@@ -77,12 +76,12 @@ class TestWritableFile:
         root = str(tmpdir.mkdir('tmp2'))
         pat = join(root, '{task}/sub-{subject}/run-{run}.nii.gz')
         target = join(root, 'rest/sub-3/run-2.nii.gz')
-        writable_file.build_file(pat, root=root)
+        writable_file.copy(pat, root=root)
         assert exists(target)
 
         # Copy into directory functionality
         pat = join(writable_file.dirname, '{task}/')
-        writable_file.build_file(pat)
+        writable_file.copy(pat)
         target = join(writable_file.dirname, 'rest', writable_file.filename)
         assert exists(target)
         shutil.rmtree(new_dir)
@@ -93,13 +92,13 @@ class TestWritableLayout:
     def test_write_files(self, tmpdir):
         data_dir = join(dirname(__file__), 'data', '7t_trt')
         config = join(dirname(__file__), 'specs', 'test.json')
-        layout = WritableLayout(data_dir, config=config)
+        layout = Layout(data_dir, config=config)
         pat = join(str(tmpdir), 'sub-{subject}'
                                 '/sess-{session}'
                                 '/r-{run}'
                                 '/type-{type}'
                                 '/task-{task}.nii.gz')
-        layout.write_files(path_patterns=pat)
+        layout.copy_files(path_patterns=pat)
         example_file = join(str(tmpdir), 'sub-02'
                                          '/sess-2'
                                          '/r-1'
@@ -111,7 +110,7 @@ class TestWritableLayout:
         contents = 'test'
         data_dir = join(dirname(__file__), 'data', '7t_trt')
         config = join(dirname(__file__), 'specs', 'test.json')
-        layout = WritableLayout(data_dir, config=config)
+        layout = Layout(data_dir, config=config)
         entities = {'subject': 'Bob', 'session': '01'}
         pat = join('sub-{subject}/sess-{session}/desc.txt')
         layout.write_contents_to_file(entities, path_patterns=pat,
@@ -128,7 +127,7 @@ class TestWritableLayout:
         contents = 'test'
         data_dir = join(dirname(__file__), 'data', '7t_trt')
         config = join(dirname(__file__), 'specs', 'test.json')
-        layout = WritableLayout(data_dir, config=[config, {
+        layout = Layout(data_dir, config=[config, {
             'default_path_patterns': ['sub-{subject}/ses-{session}/{subject}'
                                       '{session}{run}{type}{task}{acquisition}'
                                       '{bval}']

--- a/grabbit/tests/test_writable.py
+++ b/grabbit/tests/test_writable.py
@@ -47,6 +47,16 @@ class TestWritableFile:
         target = join(writable_file.dirname, 'rest/r-2.nii.gz')
         assert build_path(writable_file.entities, pats) == target
 
+    def test_strict_build_path(self):
+
+        # Test with strict matching--should fail
+        pats = ['[{session}/]{task}/r-{run}.nii.gz',
+                't-{task}/{subject}-{run}.nii.gz']
+        entities = {'subject': 1, 'task': "A", 'run': 2}
+        assert build_path(entities, pats, True)
+        entities = {'subject': 1, 'task': "A", 'age': 22}
+        assert not build_path(entities, pats, True)
+
     def test_build_file(self, writable_file, tmpdir, caplog):
         writable_file.entities = {'task': 'rest', 'run': '2', 'subject': '3'}
 


### PR DESCRIPTION
This is a reworking of the writing functionality. Instead of having separate `WritableLayout` and `WritableFile`, all writing functionality is now consolidated and simplified inside the base `Layout` and `File` classes. My apologies for making you take a detour through separate classes, @qmac; I know you originally wanted to keep this functionality inside the base classes, and I argued you out of it. It wasn't until I started mucking around with this functionality in pybids that it became clear that having separate classes was more trouble than it's worth.

Also, I think that by far the most common use case is going to be requesting the target path for a set of entities (or an existing filename), in accordance with a `Layout`'s existing `path_patterns`. So I've added a `Layout.build_path()` method that takes either a dict of entities or a `File` (or filename) and returns a path.