### PR TITLE
FIX: Exclude conditions from entity matching in strict mode

### DIFF
--- a/grabbit/extensions/writable.py
+++ b/grabbit/extensions/writable.py
@@ -85,7 +85,7 @@ def build_path(entities, path_patterns, strict=False):
     for pattern in path_patterns:
         # If strict, all entities must be contained in the pattern
         if strict:
-            defined = re.findall('\{(.*?)\}', pattern)
+            defined = re.findall('\{(.*?)(?:<[^>]+>)?\}', pattern)
             if set(entities.keys()) - set(defined):
                 continue
         # Iterate through the provided path patterns


### PR DESCRIPTION
In strict mode, we need to check against the name of the entity, with condition information (see #42) stripped.

Just to break down the regular expression (`_` used as a placeholder):

* `(?:_)` - Non-capturing, to avoid upgrading the output matches from strings to tuples of strings
* `<[^>]+>` - Only match conditions
* `_?` - Optional (obviously)

Didn't use `.*?`, by the way, just because multiple of those in a single regex can cause excessive backtracking in pathological cases. (Might not be a worry here, but still.)