### PR TITLE
Provide extra-requires with "tests" and "full" - tests need pytest-capturelog

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,14 @@ from setuptools import setup, find_packages
 if len(set(('test', 'easy_install')).intersection(sys.argv)) > 0:
     import setuptools
 
-tests_require = []
+tests_require = ['pytest-capturelog']
+# extended
+extras_require = {
+    'tests': tests_require
+}
+# just a convention to say 'pip install .[full]' to get all
+# possibly necessary dependencies installed
+extras_require['full'] = sum(list(extras_require.values()), [])
 
 VERSION = "0.1.0"
 
@@ -18,6 +25,7 @@ setup(
     packages=find_packages(exclude=['tests', 'test_*']),
     package_data={'grabbit.tests': ['data/*']},
     install_requires=[],
+    extras_require=extras_require,
     tests_require=tests_require,
     license='MIT',
     download_url='http://github.com/grabbles/grabbit/archive/%s.tar.gz' % VERSION,


### PR DESCRIPTION
not sure if that is the thing to install/do... but I have tried to run tests and then failed with
```shell
==================================================== ERRORS ====================================================
______________________________ ERROR at setup of TestWritableFile.test_build_file ______________________________
file /home/yoh/proj/bids/grabbit/grabbit/tests/test_writable.py, line 81
      def test_build_file(self, writable_file, tmpdir, caplog):
E       fixture 'caplog' not found
>       available fixtures: cache, capfd, capsys, celery_app, celery_config, celery_enable_logging, celery_includes, celery_parameters, celery_session_app, celery_session_worker, celery_worker, celery_worker_parameters, celery_worker_pool, cov, depends_on_current_app, doctest_namespace, httpserver, httpsserver, layout, monkeypatch, pytestconfig, record_xml_property, recwarn, smtpserver, tmpdir, tmpdir_factory, use_celery_app_trap, worker_id, writable_file
>       use 'pytest --fixtures [testpath]' for help on them.

```
found that 'pytest-capturelog' seems to provide that capsys fixture (that is what I don't like about pytest -- all those magically appearing and to be found fixtures).  So installed it but now it is

```
=================================================== FAILURES ===================================================
_______________________________________ TestWritableFile.test_build_file _______________________________________

self = <test_writable.TestWritableFile instance at 0x7f4f54bf3cb0>
writable_file = <grabbit.core.File object at 0x7f4f5028ddd0>
tmpdir = local('/tmp/pytest-of-yoh/pytest-1/test_build_file0')
caplog = <pytest_capturelog.CaptureLogFuncArg object at 0x7f4f502e0f50>

    def test_build_file(self, writable_file, tmpdir, caplog):
        writable_file.entities = {'task': 'rest', 'run': '2', 'subject': '3'}
    
        # Simple write out
        new_dir = join(writable_file.dirname, 'rest')
        pat = join(writable_file.dirname, '{task}/sub-{subject}/run-{run}.nii.gz')
        target = join(writable_file.dirname, 'rest/sub-3/run-2.nii.gz')
        writable_file.copy(pat)
        assert exists(target)
    
        # Conflict handling
        with pytest.raises(ValueError):
            writable_file.copy(pat)
        with pytest.raises(ValueError):
            writable_file.copy(pat, conflicts='fail')
        writable_file.copy(pat, conflicts='skip')
>       log_message = caplog.records[0].message
E       TypeError: 'instancemethod' object has no attribute '__getitem__'

grabbit/tests/test_writable.py:97: TypeError
------------------------------------------------- Captured log -------------------------------------------------
writable.py                145 WARNING  A file at path /tmp/pytest-of-yoh/pytest-1/test_build_file0/tmp/rest/sub-3/run-2.nii.gz already exists, skipping writing file.
```
so is that the wrong thing and some other capsys needed or... ?