### PR TITLE
Odds and ends

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -254,7 +254,8 @@ class LayoutMetaclass(type):
 
         paths = listify(path)
         if len(paths) == 1:
-            return super(LayoutMetaclass, cls).__call__(path, *args, **kwargs)
+            return super(LayoutMetaclass, cls).__call__(paths[0], *args,
+                                                        **kwargs)
         layouts = []
         for p in paths:
             layout = super(LayoutMetaclass, cls).__call__(p, *args, **kwargs)

--- a/grabbit/tests/specs/test.json
+++ b/grabbit/tests/specs/test.json
@@ -7,7 +7,8 @@
     {
       "name": "subject",
       "pattern": "sub-(\\d+)",
-      "directory": "{{root}}/{subject}"
+      "directory": "{{root}}/{subject}",
+      "dtype": "str"
     },
     {
       "name": "session",
@@ -18,7 +19,8 @@
     },
     {
       "name": "run",
-      "pattern": "run-0*(\\d+)"
+      "pattern": "run-(\\d+)",
+      "dtype": "int"
     },
     {
       "name": "type",

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -368,6 +368,14 @@ class TestLayout:
         files = stamp_layout.get(value='35', regex_search=True)
         assert len(files) == 2
 
+    def test_parse_file_entities(self, bids_layout):
+        filename = 'sub-03_ses-07_run-4_sekret.nii.gz'
+        with pytest.raises(ValueError):
+            bids_layout.parse_file_entities(filename)
+        ents = bids_layout.parse_file_entities(filename, domains=['test'])
+        assert ents == {'subject': '03', 'session': '7', 'run': 4,
+                        'type': 'sekret'}
+
 
 def test_merge_layouts(bids_layout, stamp_layout):
     layout = merge_layouts([bids_layout, stamp_layout])

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -200,7 +200,7 @@ class TestLayout:
         assert len(result) == 1
         assert 'phasediff.json' in result[0].filename
         assert hasattr(result[0], 'run')
-        assert result[0].run == '1'
+        assert result[0].run == 1
 
         # With exact matching...
         result = bids_layout.get(subject='1', run=1, session=1,


### PR DESCRIPTION
This PR adds two minor features:

* Adds the ability to specify a `dtype` field in JSON entity specifications (must be one of `'int'`, `'float'`, `'bool'`, or `'str'`). Closes #45.
* Adds a `parse_filename_entities` method to `Layout`. This replaces the grabbids method added in incf/pybids#123 (cc @effigies), but has slightly different semantics. In particular, because of the new `Domain` functionality, if you pass a relative path in as input, you *must* specify which named domains' entities you want to try to extract. This won't make much difference in pybids, because we can just override this method and make sure that domains is always set to all of the domains in the current `BIDSLayout`.

It also fixes some minor bugs left over from the last major PR.