### PR TITLE
Various improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,3 @@
 [run]
-source =
-	grabbit/
-omit =
-    */tests/*
+include = grabbit/
+omit = */tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,5 @@
 [run]
 include = grabbit/
-omit = */tests/*
+omit =
+	*/tests/*
+	grabbit/external/

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,4 @@
 include = grabbit/
 omit =
 	*/tests/*
-	grabbit/external/
+	*/external/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ install:
   - pip install -e '.'
 
 script:
-  - PYTHONPATH=$PWD coverage run `which py.test` grabbit
-  - py.test --cov-report term-missing --cov=grabbit
-  - cd examples; PYTHONPATH=.. runipy *.ipynb  # test example notebooks to run and not fail
+  - py.test --pyargs grabbit --cov-report term-missing --cov=grabbit
 
 after_success:
   - coveralls

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -413,7 +413,8 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
         filename = f if isinstance(f, six.string_types) else f.path
 
-        if os.path.isabs(filename) and filename.startswith(self.root + os.path.sep):
+        if os.path.isabs(filename) and filename.startswith(
+                self.root + os.path.sep):
             # for filenames under the root - analyze relative path to avoid
             # bringing injustice to the grandkids of some unfortunately named
             # root directories.
@@ -473,7 +474,13 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
     def _get_domains_for_file(self, f):
         if isinstance(f, File):
             return f.domains
-        return [d.name for d in self.domains.values() if f.startswith(d.root)]
+        domains = []
+        for d in self.domains.values():
+            for path in listify(d.root):
+                if f.startswith(path):
+                    domains.append(d.name)
+                    break
+        return domains
 
     def _index_file(self, root, f, domains=None, update_layout=True):
 
@@ -502,8 +509,8 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
         # Only keep Files that match at least one Entity, and all
         # mandatory Entities
-        if update_layout and file_ents and not (self.mandatory
-                                                - set(file_ents)):
+        if update_layout and file_ents and not (self.mandatory -
+                                                set(file_ents)):
             self.files[f.path] = f
             # Bind the File to all of the matching entities
             for name, tag in f.tags.items():

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -552,7 +552,8 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
             if self.config_filename in filenames:
                 config_path = os.path.join(root, self.config_filename)
                 config = json.load(open(config_path, 'r'))
-                self._load_domain(config)
+                root = config.get('root', root)
+                self._load_domain(config, root=root)
 
                 # Filter Domains if current dir's config file has an
                 # include directive

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -139,15 +139,15 @@ class Domain(object):
         self.root = root
         self.entities = {}
         self.files = []
-        self.filtering_regex = {}
         self.path_patterns = []
 
-        if 'index' in config:
-            self.filtering_regex = config['index']
-            if self.filtering_regex.get('include') and \
-               self.filtering_regex.get('exclude'):
-                raise ValueError("You can only define either include or "
-                                 "exclude regex, not both.")
+        self.include = self.config.get('include', [])
+        self.exclude = self.config.get('exclude', [])
+
+        if self.include and self.exclude:
+            raise ValueError("The 'include' and 'exclude' arguments cannot "
+                             "both be set. Please pass at most one of these "
+                             "for domain '%s'." % self.name)
 
         if 'default_path_patterns' in config:
             self.path_patterns += listify(config['default_path_patterns'])
@@ -450,7 +450,7 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
         for dom in domains:
             dom = self.domains[dom]
             # If file matches any include regex, then True
-            include_regex = dom.filtering_regex.get('include', [])
+            include_regex = dom.include
             if include_regex:
                 for regex in include_regex:
                     if re.match(regex, filename):
@@ -459,7 +459,7 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
                     return False
             else:
                 # If file matches any excldue regex, then false
-                for regex in dom.filtering_regex.get('exclude', []):
+                for regex in dom.exclude:
                     if re.match(regex, filename, flags=re.UNICODE):
                         return False
 

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -122,6 +122,17 @@ class File(object):
 class Domain(object):
 
     def __init__(self, name, config, root):
+        """
+        A set of rules that applies to one or more directories
+        within a Layout.
+
+        Args:
+            name (str): The name of the Domain.
+            config (dict): The configuration dictionary that defines the
+                entities and paths for the current domain.
+            root (str, list): The root directory or directories to which the
+                Domain's rules applies. Can be either a single path, or a list.
+        """
 
         self.name = name
         self.config = config
@@ -142,9 +153,19 @@ class Domain(object):
             self.path_patterns += listify(config['default_path_patterns'])
 
     def add_entity(self, ent):
+        ''' Add an Entity.
+
+        Args:
+            ent (Entity): The Entity to add.
+        '''
         self.entities[ent.name] = ent
 
     def add_file(self, file):
+        ''' Add a file to tracking.
+
+        Args:
+            file (File): The File to add to tracking.
+        '''
         self.files.append(file)
 
 
@@ -287,10 +308,13 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
         Args:
             path (str): The root path of the layout.
-            config (str, list): The path to the JSON config file that defines
-                the entities and paths for the current layout. If a list is
-                provided, treat as several paths to config files, creating
-                one master config with all of them merged (in order).
+            config (str, list, dict): A specification of the configuration
+                file(s) defining domains to use in the Layout. Must be one of:
+
+                - A dictionary containing config information
+                - A string giving the path to a JSON file containing the config
+                - A list, where each element is one of the above
+
             index (str): Optional path to a saved index file. If a valid value
                 is passed, this index is used to populate Files and Entities,
                 and the normal indexing process (which requires scanning all

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -556,8 +556,8 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
                 # Filter Domains if current dir's config file has an
                 # include directive
-                if 'include' in config:
-                    missing = set(config['include']) - set(domains)
+                if 'domains' in config:
+                    missing = set(config['domains']) - set(domains)
                     if missing:
                         msg = ("Missing configs '%s' specified in include "
                                "directive of config '%s'. Please make sure "
@@ -565,7 +565,7 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
                                "directory %s.") % (missing, config['name'],
                                                    root)
                         raise ValueError(msg)
-                    domains = config['include']
+                    domains = config['domains']
                 domains.append(config['name'])
 
                 filenames.remove(self.config_filename)

--- a/grabbit/tests/specs/test.json
+++ b/grabbit/tests/specs/test.json
@@ -1,8 +1,6 @@
 {
   "name": "test",
-  "index" : {
-    "exclude" : [".*derivatives.*"]
-  },
+  "exclude" : [".*derivatives.*"],
   "entities": [
     {
       "name": "subject",

--- a/grabbit/tests/specs/test_include.json
+++ b/grabbit/tests/specs/test_include.json
@@ -1,8 +1,6 @@
 {
   "name": "test_with_includes",
-  "index" : {
-    "include" : ["sub-(\\d+)", "ses-.*", "func", "fmap", ".*\\..*"]
-  },
+  "include" : ["sub-(\\d+)", "ses-.*", "func", "fmap", ".*\\..*"],
   "entities": [
     {
       "name": "subject",

--- a/grabbit/tests/specs/test_with_mapper.json
+++ b/grabbit/tests/specs/test_with_mapper.json
@@ -1,8 +1,6 @@
 {
   "name": "test_with_mapper",
-  "index" : {
-    "exclude" : [".*derivatives.*"]
-  },
+  "exclude" : [".*derivatives.*"],
   "entities": [
     {
       "name": "subject",


### PR DESCRIPTION
This PR contains a number of improvements:
* Simplified and more sensible config files; the `include` and `exclude` directives are now at the root level instead of being nested within `index`; the previous `include` directive that names which domains to inherit from is now renamed to `domains` to prevent confusion.
* Domains can now have multiple roots (i.e., one can pass a list of directories the `Domain` applies to, instead of just a single path).
* Global `include` and `exclude` arguments have been added to the `Layout` initializer; these behave just like the config include/exclude for individual Domains, but apply globally to all files (and cannot be overridden by domain configs).
* Fixes coveralls (closes #50)