### PR TITLE
WIP: correct relative domain roots #57

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -599,8 +599,10 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
             if self.config_filename in filenames:
                 config_path = os.path.join(root, self.config_filename)
                 config = json.load(open(config_path, 'r'))
-                root = config.get('root', root)
-                self._load_domain(config, root=root)
+                cfg_root = config.get('root', root)
+                if cfg_root == '.':
+                    cfg_root = root
+                self._load_domain(config, root=cfg_root)
 
                 # Filter Domains if current dir's config file has an
                 # include directive


### PR DESCRIPTION
This currently doesn't work because relative paths are appended to the root regardless: https://github.com/grabbles/grabbit/blob/ef297b0a858c9955543c68e19ba6ee8a73b580a9/grabbit/core.py#L414-L423

One way I see around this is to keep the current behavior in `_load_domains` for relative roots (append to layout root), but relativise the domain root before calling `_load_domains`.  This should AFAIK work well since the root specified to start `walk` is going to be the layout root (whether that's absolute or relative).