### PR TITLE
replaces keywords with non-conflicting entity names in namedtuples

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -9,6 +9,7 @@ from os.path import (join, basename, dirname, abspath, split, isabs, exists)
 from functools import partial
 from copy import deepcopy
 import warnings
+from keyword import iskeyword
 
 
 __all__ = ['File', 'Entity', 'Layout']
@@ -90,7 +91,18 @@ class File(object):
         Returns the File as a named tuple. The full path plus all entity
         key/value pairs are returned as attributes.
         """
-        entities = self.entities
+        keys = list(self.entities.keys())
+        replaced = []
+        for i, k in enumerate(keys):
+            if iskeyword(k):
+                replaced.append(k)
+                keys[i] = '%s_' % k
+        if replaced:
+            safe = ['%s_' % k for k in replaced]
+            warnings.warn("Entity names cannot be reserved keywords when "
+                          "representing a File as a namedtuple. Replacing "
+                          "entities %s with safe versions %s." % (keys, safe))
+        entities = dict(zip(keys, self.entities.values()))
         _File = namedtuple('File', 'filename ' + ' '.join(entities.keys()))
         return _File(filename=self.path, **entities)
 


### PR DESCRIPTION
Fixes #56. Note that this is not an ideal solution; the original bug highlights a design flaw, which is that we shouldn't be creating `namedtuple` classes with dynamic attributes. This probably calls for replacing the `namedtuple` return option with a standard `dict`. But since that would be a breaking change (especially because `tuple` is the default return format), this will have to wait for the next major release. (Alternatively, we could keep the returned object as a namedtuple, but move all of the entities into a single `.entities` field, to be consistent with the `File` object itself).