### PR TITLE
ENH: Use key=None to filter for files that do not contain entity

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -66,8 +66,11 @@ class File(object):
 
             for name, val in entities.items():
 
-                if name not in self.tags:
+                if (name not in self.tags) ^ (val is None):
                     return False
+
+                if val is None:
+                    continue
 
                 def make_patt(x):
                     patt = '%s' % x


### PR DESCRIPTION
It is occasionally useful to have a strict match for some filename entities, but not others. For a BIDS example, to look for files at the dataset level, you would want to exclude files with a subject entity. This patch allows you to use `layout.get(subject=None)` to find such files.