### PR TITLE
FIX: Do not assume domains is not None

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -545,6 +545,9 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
         # Create the file object--allows for subclassing
         f = self._make_file_object(root, f)
 
+        if domains is None:
+          domains = []
+
         for d in listify(domains):
             if d not in self.domains:
                 raise ValueError("Cannot index file '%s' in domain '%s'; "


### PR DESCRIPTION
```Python
  File "/opt/conda/envs/neuro/bin/fitlins", line 11, in <module>
    load_entry_point('fitlins', 'console_scripts', 'fitlins')()
  File "/src/fitlins/fitlins/cli/run.py", line 105, in main
    create_workflow(opts)
  File "/src/fitlins/fitlins/cli/run.py", line 165, in create_workflow
    report_dicts = parse_directory(deriv_dir, analysis)
  File "/src/fitlins/fitlins/viz/reports.py", line 38, in parse_directory
    ents = fl_layout.parse_file_entities(contrast_svg.filename)
  File "/opt/conda/envs/neuro/lib/python3.6/site-packages/grabbit/core.py", line 959, in parse_file_entities
    result = self._index_file(root, f, domains, update_layout=False)
  File "/opt/conda/envs/neuro/lib/python3.6/site-packages/grabbit/core.py", line 548, in _index_file
    for d in listify(domains):
TypeError: 'NoneType' object is not iterable
```