### PR TITLE
Better domain configuration and path handling

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -322,7 +322,7 @@ class LayoutMetaclass(type):
 
 class Layout(six.with_metaclass(LayoutMetaclass, object)):
 
-    def __init__(self, root=None, config=None, index=None,
+    def __init__(self, paths=None, root=None, index=None,
                  dynamic_getters=False, absolute_paths=True,
                  regex_search=False, entity_mapper=None, path_patterns=None,
                  config_filename='layout.json', include=None, exclude=None):
@@ -330,21 +330,23 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
         A container for all the files and metadata found at the specified path.
 
         Args:
-            root (str): Directory that all other paths will be relative to.
-            Every other path the Layout sees must be at this level or below.
-            domains (str, list, dict): A specification of the configuration
-                object(s) defining domains to use in the Layout. Can be one of:
+            paths (str, list): The path(s) where project files are located.
+                Must be one of:
 
-                - A dictionary containing config information
-                - A string giving the path to a JSON file containing the config
-                - A string giving the path to a directory containing a
-                  configuration file with the name defined in config_filename
-                - A tuple with two elements, where the first element is one of
-                  the above (i.e., dict or string), and the second element is
-                  an iterable of directories to apply the config to.
-                - A list, where each element is any of the above (dict, string,
-                  or tuple).
+                - A path to a directory containing files to index
+                - A list of paths to directories to index
+                - A list of 2-tuples where each tuple encodes a mapping from
+                  directories to domains. The first element is a string or
+                  list giving the paths to one or more directories to index.
+                  The second element specifies which domains to apply to the
+                  specified files, and can be one of:
+                    * A string giving the path to a JSON config file
+                    * A dictionary containing config information
+                    * A list of any combination of strings or dicts
 
+            root (str): Optional directory that all other paths will be
+                relative to. If set, every other path the Layout sees must be
+                at this level or below. If None, filesystem root ('/') is used.
             index (str): Optional path to a saved index file. If a valid value
                 is passed, this index is used to populate Files and Entities,
                 and the normal indexing process (which requires scanning all
@@ -407,6 +409,8 @@ class Layout(six.with_metaclass(LayoutMetaclass, object)):
         self.include = listify(include or [])
         self.exclude = listify(exclude or [])
         self.absolute_paths = absolute_paths
+        if root is None:
+            root = '/'
         self.root = abspath(root) if absolute_paths else root
 
         if config is not None:

--- a/grabbit/extensions/writable.py
+++ b/grabbit/extensions/writable.py
@@ -130,7 +130,8 @@ def write_contents_to_file(path, contents=None, link_to=None,
             'overwrite' overwrites the existing file; 'append' adds  a suffix
             to each file copy, starting with 1. Default is 'fail'.
     """
-    if not root and not isabs(path):
+
+    if root is None and not isabs(path):
         root = os.getcwd()
 
     if root:

--- a/grabbit/tests/test_writable.py
+++ b/grabbit/tests/test_writable.py
@@ -18,7 +18,8 @@ def writable_file(tmpdir):
 def layout():
     data_dir = join(dirname(__file__), 'data', '7t_trt')
     config = join(dirname(__file__), 'specs', 'test.json')
-    layout = Layout(data_dir, config, absolute_paths=False)
+    layout = Layout([(data_dir, config)], absolute_paths=False,
+                    root=data_dir)
     return layout
 
 
@@ -204,12 +205,12 @@ class TestWritableLayout:
         contents = 'test'
         data_dir = join(dirname(__file__), 'data', '7t_trt')
         config = join(dirname(__file__), 'specs', 'test.json')
-        layout = Layout(data_dir, [config, {
+        layout = Layout([(data_dir, [config, {
             'name': "test_writable",
             'default_path_patterns': ['sub-{subject}/ses-{session}/{subject}'
                                       '{session}{run}{type}{task}{acquisition}'
                                       '{bval}']
-        }])
+        }])], root=data_dir)
         entities = {'subject': 'Bob', 'session': '01', 'run': '1',
                     'type': 'test', 'task': 'test', 'acquisition': 'test',
                     'bval': 0}

--- a/grabbit/utils.py
+++ b/grabbit/utils.py
@@ -29,7 +29,7 @@ def splitext(path):
     return li
 
 
-def listify(obj):
+def listify(obj, ignore=(list, tuple, type(None))):
     ''' Wraps all non-list or tuple objects in a list; provides a simple way
     to accept flexible arguments. '''
-    return obj if isinstance(obj, (list, tuple, type(None))) else [obj]
+    return obj if isinstance(obj, ignore) else [obj]


### PR DESCRIPTION
This is a major, backward-incompatible refactoring of the core code that introduces three major changes:

* The `root` and `config` arguments have been replaced by `paths` and `root`. There is no longer any single mandatory root path for a `Layout`; instead, the `root` now defines only an (optional) directory that all other filenames are made relative to when querying. The `config` argument has been replaced with a (mandatory) `paths` argument that behaves in much the same way, except that the specification of tuples within a list has changed (see docstring for explanation).

* Instead of absolute vs. relative paths being determined on-the-fly for each file, all paths are now stored as absolute paths internally, and the `absolute_paths` flag is only applied when querying via `Layout.get()`. This reduces internal code complexity with little impact on the end user.

* File indexing is now substantially more efficient in most cases (this has no impact on the user-facing API).