### PR TITLE
ENH: Add full_search option to get_nearest

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -833,7 +833,7 @@ class Layout(object):
         return data
 
     def get_nearest(self, path, return_type='file', strict=True, all_=False,
-                    ignore_strict_entities=None, **kwargs):
+                    ignore_strict_entities=None, new_param=False, **kwargs):
         ''' Walk up the file tree from the specified path and return the
         nearest matching file(s).
 
@@ -883,11 +883,16 @@ class Layout(object):
         matches = []
 
         search_paths = [path]
-        while search_paths[:-1] != '/':
+        while search_paths[-1] != '/':
+            if new_param and search_paths[-1] in folders:
+                new_param = False
             parent = dirname(search_paths[-1])
             if parent == search_paths[-1]:
                 break
             search_paths.append(parent)
+
+        if new_param:
+            search_paths.extend(folders.keys())
 
         for path in search_paths:
             if path in folders and folders[path]:

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -882,7 +882,14 @@ class Layout(object):
 
         matches = []
 
-        while True:
+        search_paths = [path]
+        while search_paths[:-1] != '/':
+            parent = dirname(search_paths[-1])
+            if parent == search_paths[-1]:
+                break
+            search_paths.append(parent)
+
+        for path in search_paths:
             if path in folders and folders[path]:
 
                 # Sort by number of matching entities. Also store number of
@@ -899,13 +906,6 @@ class Layout(object):
 
                 if not all_:
                     break
-            try:
-                _path, _ = split(path)
-                if _path == path:
-                    break
-                path = _path
-            except Exception:
-                break
 
         matches = [m.path if return_type == 'file' else m.as_named_tuple()
                    for m in matches]

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -892,7 +892,7 @@ class Layout(object):
             search_paths.append(parent)
 
         if full_search:
-            search_paths.extend(folders.keys())
+            search_paths.extend(set(folders.keys()) - set(search_paths))
 
         for path in search_paths:
             if path in folders and folders[path]:

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -833,7 +833,7 @@ class Layout(object):
         return data
 
     def get_nearest(self, path, return_type='file', strict=True, all_=False,
-                    ignore_strict_entities=None, new_param=False, **kwargs):
+                    ignore_strict_entities=None, full_search=False, **kwargs):
         ''' Walk up the file tree from the specified path and return the
         nearest matching file(s).
 
@@ -884,14 +884,14 @@ class Layout(object):
 
         search_paths = [path]
         while search_paths[-1] != '/':
-            if new_param and search_paths[-1] in folders:
-                new_param = False
+            if full_search and not all_ and search_paths[-1] in folders:
+                full_search = False
             parent = dirname(search_paths[-1])
             if parent == search_paths[-1]:
                 break
             search_paths.append(parent)
 
-        if new_param:
+        if full_search:
             search_paths.extend(folders.keys())
 
         for path in search_paths:


### PR DESCRIPTION
This PR adds a `full_search` parameter to `Layout.get_nearest`, that permits "nearest" files to be found throughout the layout, in cases where not all files share a common root.

The approach is to split search path creation from the actual search. If `full_search` is enabled, then the search will extend to all matching `folders`.