### PR TITLE
Default path segments

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -855,6 +855,9 @@ class Layout(object):
                 one to search, e.g., for files of a different type while
                 matching all other entities perfectly by passing
                 ignore_strict_entities=['type'].
+            full_search (bool): If True, searches all indexed files, even if
+                they don't share a common root with the provided path. If
+                False, only files that share a common root will be scanned.
             kwargs: Optional keywords to pass on to .get().
         '''
 

--- a/grabbit/tests/test_writable.py
+++ b/grabbit/tests/test_writable.py
@@ -75,6 +75,16 @@ class TestWritableFile:
         target = join(writable_file.dirname, 'r-2.nii.gz')
         assert build_path(writable_file.entities, pats) == target
 
+        # Pattern with default value
+        pats = ['sess-{session|A}/r-{run}.nii.gz']
+        assert build_path({'run': 3}, pats) == 'sess-A/r-3.nii.gz'
+
+        # Pattern with both valid and default values
+        pats = ['sess-{session<A|B|C>|D}/r-{run}.nii.gz']
+        assert build_path({'session': 1, 'run': 3}, pats) == 'sess-D/r-3.nii.gz'
+        pats = ['sess-{session<A|B|C>|D}/r-{run}.nii.gz']
+        assert build_path({'session': 'B', 'run': 3}, pats) == 'sess-B/r-3.nii.gz'
+
     def test_strict_build_path(self):
 
         # Test with strict matching--should fail


### PR DESCRIPTION
Addresses #82. Now allows segments to be specified like `"{session}<[0-9]+>|0}"`, where the part after the pipe specifies a default value to fall back on if no value exists or a value exists but it's not one of the specified valid values.