### PR TITLE
RF File's namedtuple to reflect 1-to-1 File's attributes (path, filename, dirname)

### DIFF
--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -104,8 +104,8 @@ class File(object):
                           "representing a File as a namedtuple. Replacing "
                           "entities %s with safe versions %s." % (keys, safe))
         entities = dict(zip(keys, self.entities.values()))
-        _File = namedtuple('File', 'path filename dirname ' + ' '.join(entities.keys()))
-        return _File(path=self.path,
+        _FileTuple = namedtuple('FileTuple', 'path filename dirname ' + ' '.join(entities.keys()))
+        return _FileTuple(path=self.path,
                      filename=self.filename, dirname=self.dirname,
                      **entities)
 

--- a/grabbit/core.py
+++ b/grabbit/core.py
@@ -104,8 +104,10 @@ class File(object):
                           "representing a File as a namedtuple. Replacing "
                           "entities %s with safe versions %s." % (keys, safe))
         entities = dict(zip(keys, self.entities.values()))
-        _File = namedtuple('File', 'filename ' + ' '.join(entities.keys()))
-        return _File(filename=self.path, **entities)
+        _File = namedtuple('File', 'path filename dirname ' + ' '.join(entities.keys()))
+        return _File(path=self.path,
+                     filename=self.filename, dirname=self.dirname,
+                     **entities)
 
     def copy(self, path_patterns, symbolic_link=False, root=None,
              conflicts='fail'):

--- a/grabbit/tests/test_core.py
+++ b/grabbit/tests/test_core.py
@@ -84,7 +84,7 @@ class TestFile:
         file = copy(file)
         file.tags = {'attrA': Tag(None, 'apple'), 'attrB': Tag(None, 'banana')}
         tup = file.as_named_tuple()
-        assert(tup.filename == file.path)
+        assert(tup.path == file.path)
         assert isinstance(tup, tuple)
         assert not hasattr(tup, 'task')
         assert tup.attrA == 'apple'
@@ -203,12 +203,13 @@ class TestLayout:
             layout = Layout([(root, config)], absolute_paths=True)
             result = layout.get(subject=1, run=1, session=1)
             assert result
-            assert all([os.path.isabs(f.filename) for f in result])
+            assert all([os.path.isabs(f.path) for f in result])
+            assert not any([os.path.isabs(f.filename) for f in result])
 
             layout = Layout([(root, config)], absolute_paths=False)
             result = layout.get(subject=1, run=1, session=1)
             assert result
-            assert not any([os.path.isabs(f.filename) for f in result])
+            assert not any([os.path.isabs(f.path) for f in result])
 
         # Should always be absolute paths on HDFS
         else:


### PR DESCRIPTION
Initially ran into the problem while trying to go through [pybids's tutorial](https://github.com/bids-standard/pybids/blob/master/examples/pybids%20tutorial.ipynb) which would fail now since there is no .path in the "File" (tuple) provided to `get` call

- [x] Made `File.path` stored as `.path` of namedtuple, and then filename and dirname in corresponding fields as well
- [x] renamed named tuple from "File" to "FileTuple" to make it explicit

Both changes are questionable (feel welcome to fix some other way) since I am not exactly sure on the "life span" of the namedtuple here and either other ways (make `File` hashable) for intended use (using as dict keys?) were considered... if it was intended to be used later to "reinstantiate" `File` object, then it would fail since that one needs only "filename" which gets assigned to "path" (khe khe) and the other two are recomputed.  Probably if that was intended, namedtuple would need to store also initial class.

Obviously that this change does brake pybids, but the point is that there seems to be this inconsistency and pybids seems to be broken anyways already according to that example failures.  With this change and master of grabbit I am getting "9 failed, 101 passed, 10 warnings, 1 error" in pybids (with 111 passed without).