### PR TITLE
MAINT: Add mailmap to map contributor tags to authors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,5 @@ ENV/
 *.orig
 
 .pytest_cache
+
+.*.swp

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,15 @@
+Alejandro de la Vega <delavega@utexas.edu> adelavega <delavega@utexas.edu>
+Christopher J. Markiewicz <markiewicz@stanford.edu> Chris Markiewicz <effigies@gmail.com>
+Christopher J. Markiewicz <markiewicz@stanford.edu> Chris Markiewicz <markiewicz@stanford.edu>
+Dave F. Kleinschmidt <dave.f.kleinschmidt@gmail.com> Dave Kleinschmidt <dave.f.kleinschmidt@gmail.com>
+Jean-Baptiste Poline <jbpoline@gmail.com> JB <jbpoline@gmail.com>
+Jean-Baptiste Poline <jbpoline@gmail.com> JB Poline <jbpoline@gmail.com>
+Jean-Baptiste Poline <jbpoline@gmail.com> Jean-Baptiste Poline <jbpoline@users.noreply.github.com>
+John A. Lee <johnleenimh@gmail.com> leej3 <johnleenimh@gmail.com>
+Krzysztof J. Gorgolewski <krzysztof.gorgolewski@gmail.com> Chris Gorgolewski <krzysztof.gorgolewski@gmail.com>
+Pauline Roca <roca.pauline@gmail.com> PaulineRoca <roca.pauline@gmail.com>
+Quinten McNamara <quinten.mcnamara@gmail.com> qmac <quinten.mcnamara@gmail.com>
+Russell A. Poldrack <poldrack@gmail.com> poldrack <poldrack@gmail.com>
+Tal Yarkoni <tyarkoni@gmail.com> tyarkoni <tyarkoni@gmail.com>
+Valérie Hayot-Sasson <valeriehayot@gmail.com> Valerie Hayot-Sasson <valeriehayot@gmail.com>
+Yaroslav O. Halchenko <debian@onerussian.com> Yaroslav Halchenko <debian@onerussian.com>


### PR DESCRIPTION
The purpose of this pull request is to establish author names for grabbit contributors, which will appear in pybids Zenodo releases (see https://github.com/bids-standard/pybids/pull/308#issuecomment-443365498).

Since the contributors to grabbit who aren't pybids contributors is a pretty small set, I took the liberty of looking you up in PubMed and making a guess at how you print your names in publication. Please comment or thumbs-up this post if your name is how you would wish it in a Zenodo publication. Otherwise, please suggest an alternative.

cc @kleinschmidt @jbpoline @leej3 @PaulineRoca @qmac @poldrack @ValHayot 