### PR TITLE
Added LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include LICENSE
 include versioneer.py
 include grabbit/_version.py
 recursive-include grabbit/tests data misc specs


### PR DESCRIPTION
This patch adds the `LICENSE` file to `MANIFEST.in` so that it is included in distribution tarballs.